### PR TITLE
Add ribcounts to sample metadata for dashboard deployment

### DIFF
--- a/dashboard/prepare-dashboard-data.py
+++ b/dashboard/prepare-dashboard-data.py
@@ -274,6 +274,7 @@ virus_sample_counts = defaultdict(Counter)
 
 # sample -> {metadata}
 sample_metadata = defaultdict(dict)
+
 for project in projects:
     with open("%s/bioprojects/%s/metadata/metadata.tsv" % (
             ROOT_DIR, project)) as inf:
@@ -288,6 +289,15 @@ for project in projects:
     for sample in project_sample_reads[project]:
         sample_metadata[sample]["reads"] = \
             project_sample_reads[project][sample]
+
+        rc_fname = "ribocounts/%s.ribocounts.txt" % sample
+        try:
+            with open(rc_fname, 'r') as file:
+                content = file.read().strip()
+                ribocount = int(content)
+            sample_metadata[sample]["ribocounts"] = ribocount
+        except FileNotFoundError:
+            continue
 
 for taxid in observed_taxids:
     for project in projects:

--- a/dashboard/prepare-dashboard-data.py
+++ b/dashboard/prepare-dashboard-data.py
@@ -293,11 +293,10 @@ for project in projects:
         rc_fname = "ribocounts/%s.ribocounts.txt" % sample
         try:
             with open(rc_fname, 'r') as file:
-                content = file.read().strip()
-                ribocount = int(content)
+                ribocount = int(file.read().strip())
             sample_metadata[sample]["ribocounts"] = ribocount
         except FileNotFoundError:
-            continue
+            pass
 
 for taxid in observed_taxids:
     for project in projects:

--- a/dashboard/prepare-dashboard-data.sh
+++ b/dashboard/prepare-dashboard-data.sh
@@ -20,6 +20,7 @@ cd $ROOT_DIR/dashboard
 mkdir -p allmatches/
 mkdir -p hvreads/
 mkdir -p hvrfull/
+mkdir -p ribocounts/
 
 if [ ! -e names.dmp ] ; then
     wget https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump_archive/taxdmp_2022-12-01.zip
@@ -47,6 +48,15 @@ for study in $(aws s3 ls $S3_DIR | awk '{print $NF}'); do
         fi
     done
 done | xargs -I {} -P 32 aws s3 cp {} hvreads/
+
+for study in $(aws s3 ls $S3_DIR | awk '{print $NF}'); do
+    for rc in $(aws s3 ls $S3_DIR${study}ribocounts/ | \
+                    awk '{print $NF}'); do
+    	if [ ! -s ribocounts/$rc ]; then
+	    echo $S3_DIR${study}ribocounts/$rc
+	fi
+     done
+done | xargs -I {} -P 32 aws s3 cp {} ribocounts/
 
 $MGS_PIPELINE_DIR/dashboard/prepare-dashboard-data.py $ROOT_DIR $MGS_PIPELINE_DIR
 

--- a/run.py
+++ b/run.py
@@ -265,7 +265,7 @@ def ribocounts(args):
                     "ribodetector_cpu",
                     "--ensure", "rrna",
                     "--threads", "24",
-                    "--chunk_size", "256"
+                    "--chunk_size", "512"
                     ]
                 ribodetector_cmd.extend(["--len", str(avg_length)])
 

--- a/run.py
+++ b/run.py
@@ -264,7 +264,8 @@ def ribocounts(args):
                 ribodetector_cmd = [
                     "ribodetector_cpu",
                     "--ensure", "rrna",
-                    "--threads", "24"
+                    "--threads", "24",
+                    "--chunk_size", "256"
                     ]
                 ribodetector_cmd.extend(["--len", str(avg_length)])
 


### PR DESCRIPTION
Tested my running `prepare-dashboard-data.sh` which successfully completed and saved ribocounts to `sample_metadata[sample]["ribocounts"]` in cases where the file exists. 

Also added a `--chunk_size` argument to the ribocounts function in `run.py` to address memory issues which I suspect were causing the screen processes to die. 