### PR TITLE
Adding feature to ribocounts that saves non-rRNA read IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ dashboard/hvreads/
 dashboard/top_species_counts/
 dashboard/top_species_scratch/
 dashboard/allmatches/
-dashboard/ribocounts/
+dashboard/riboreads/

--- a/README.md
+++ b/README.md
@@ -101,15 +101,10 @@ Available files, and their formats:
      * `discarded` if it dropped the whole pair
      * Plus a `settings` file with info on how cleaning went
 
-* `ribocounts/`: Intermediate, counts of `RiboDetector` output
-    * ex: SRR13167443.ribocounts.txt
+* `riboreads/`: Intermediate, read IDs of `RiboDetector` output
+    * ex: SRR13167436.riboreads.txt.gz
     * txt
-    * Stores the number of rRNA reads in a sample.
-
-* `ribopass-reads/`: Intermediate, read IDs of `RiboDetector` output
-    * ex: SRR13711926.ribopass.txt.gz
-    * txt
-    * Stores non-rRNA read IDs 
+    * Stores rRNA read IDs 
 
 * `processed/`: Intermediate, output of `Kraken2`
    * ex: `SRR14530724.collapsed.kraken2.tsv.gz`

--- a/README.md
+++ b/README.md
@@ -101,10 +101,15 @@ Available files, and their formats:
      * `discarded` if it dropped the whole pair
      * Plus a `settings` file with info on how cleaning went
 
-* `ribocounts/`: Intermediate, processed output of `RiboDetector`
+* `ribocounts/`: Intermediate, counts of `RiboDetector` output
     * ex: SRR13167443.ribocounts.txt
     * txt
     * Stores the number of rRNA reads in a sample.
+
+* `ribopass-reads/`: Intermediate, read IDs of `RiboDetector` output
+    * ex: SRR13711926.ribopass.txt.gz
+    * txt
+    * Stores non-rRNA read IDs 
 
 * `processed/`: Intermediate, output of `Kraken2`
    * ex: `SRR14530724.collapsed.kraken2.tsv.gz`

--- a/dashboard/prepare-dashboard-data.py
+++ b/dashboard/prepare-dashboard-data.py
@@ -301,10 +301,10 @@ for project in projects:
         sample_metadata[sample]["reads"] = \
             project_sample_reads[project][sample]
 
-        rc_fname = "ribocounts/%s.ribocounts.txt" % sample
+        rr_fname = "riboreads/%s.riboreads.txt.gz" % sample
         try:
-            with open(rc_fname, 'r') as file:
-                ribocount = int(file.read().strip())
+            with gzip.open(rr_fname, 'rt') as file:
+                ribocount = sum(1 for _ in file)
             sample_metadata[sample]["ribocounts"] = ribocount
         except FileNotFoundError:
             pass

--- a/dashboard/prepare-dashboard-data.sh
+++ b/dashboard/prepare-dashboard-data.sh
@@ -20,7 +20,7 @@ cd $ROOT_DIR/dashboard
 mkdir -p allmatches/
 mkdir -p hvreads/
 mkdir -p hvrfull/
-mkdir -p ribocounts/
+mkdir -p riboreads/
 
 if [ ! -e names.dmp ] ; then
     wget https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump_archive/taxdmp_2022-12-01.zip
@@ -50,13 +50,13 @@ for study in $(aws s3 ls $S3_DIR | awk '{print $NF}'); do
 done | xargs -I {} -P 32 aws s3 cp {} hvreads/
 
 for study in $(aws s3 ls $S3_DIR | awk '{print $NF}'); do
-    for rc in $(aws s3 ls $S3_DIR${study}ribocounts/ | \
+    for rc in $(aws s3 ls $S3_DIR${study}riboreads/ | \
                     awk '{print $NF}'); do
-    	if [ ! -s ribocounts/$rc ]; then
-	    echo $S3_DIR${study}ribocounts/$rc
+    	if [ ! -s riboreads/$rc ]; then
+	    echo $S3_DIR${study}riboreads/$rc
 	fi
      done
-done | xargs -I {} -P 32 aws s3 cp {} ribocounts/
+done | xargs -I {} -P 32 aws s3 cp {} riboreads/
 
 $MGS_PIPELINE_DIR/dashboard/prepare-dashboard-data.py $ROOT_DIR $MGS_PIPELINE_DIR
 

--- a/run.py
+++ b/run.py
@@ -314,15 +314,10 @@ def riboreads(args):
             riboreads_file = os.path.join(workdir, f"{sample}.riboreads.txt")
             gzipped_file_path = riboreads_file + ".gz"
 
-            # Write text file
-            with open(riboreads_file, 'w') as file:
+            # Write and gzip the text file
+            with gzip.open(gzipped_file_path, 'wb') as gzipped_file:
                 for title in sample_rrna_reads:
-                    file.write(title + '\n')
-
-            # Gzip the text file
-            with open(riboreads_file, 'rb') as orig_file:
-                with gzip.open(gzipped_file_path, 'wb') as gzipped_file:
-                    gzipped_file.writelines(orig_file)
+                    gzipped_file.write(title + '\n')
             
             subprocess.check_call([
                 "aws", "s3", "cp", gzipped_file_path, "%s/%s/riboreads/" % (

--- a/run.py
+++ b/run.py
@@ -314,7 +314,7 @@ def ribocounts(args):
         # Save titles of non-rRNA reads
         # For paired-end reads, only the title of the first reads is saved
         with tempdir("ribopass_reads", sample + "_output2") as workdir:
-            ribopass_reads_file = os.path.join(workdir, f"{sample}_ribopass_reads.txt")
+            ribopass_reads_file = os.path.join(workdir, f"{sample}.ribopass.txt")
             gzipped_file_path = ribopass_reads_file + ".gz"
 
             # Write text file

--- a/run.py
+++ b/run.py
@@ -313,14 +313,22 @@ def ribocounts(args):
 
         # Save titles of non-rRNA reads
         # For paired-end reads, only the title of the first reads is saved
-        with tempdir("ribopass_reads", sample + "_output2") as workdirea
+        with tempdir("ribopass_reads", sample + "_output2") as workdir:
             ribopass_reads_file = os.path.join(workdir, f"{sample}_ribopass_reads.txt")
+            gzipped_file_path = ribopass_reads_file + ".gz"
+
+            # Write text file
             with open(ribopass_reads_file, 'w') as file:
                 for title in sample_nonrrna_reads:
                     file.write(title + '\n')
+
+            # Gzip the text file
+            with open(ribopass_reads_file, 'rb') as orig_file:
+                with gzip.open(gzipped_file_path, 'wb') as gzipped_file:
+                    gzipped_file.writelines(orig_file)
             
             subprocess.check_call([
-                "aws", "s3", "cp", ribopass_reads_file, "%s/%s/ribopass-reads/" % (
+                "aws", "s3", "cp", gzipped_file_path, "%s/%s/ribopass-reads/" % (
                     S3_BUCKET, args.bioproject)])
 
 


### PR DESCRIPTION
RiboDetector takes a long time to run and we're currently only saving the number of rRNA reads. If we want to know the rRNA status of a read, we'd have to run it through RiboDetector again.  I expect this information to be useful in the future, and it's of very little cost to save the read IDs.

Here, I add a feature that saves a text file of non-rRNA read IDs in a sample, with the IDs parsed by `FastqGeneralIterator`. The text file is saved to an AWS directory within each bioproject called `ribopass-reads/`.

Question: Is it worth compressing the text files before copying them to AWS?

- Update: I'm now compressing txt files before copying them to AWS