### PR TITLE
Get rRNA fraction with fast ribocounts()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dashboard/top_species_scratch/
 dashboard/allmatches/
 dashboard/riboreads/
 dashboard/ribocounts/
+dashboard/ribofrac/

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dashboard/top_species_counts/
 dashboard/top_species_scratch/
 dashboard/allmatches/
 dashboard/riboreads/
+dashboard/ribocounts/

--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ Available files, and their formats:
      * `discarded` if it dropped the whole pair
      * Plus a `settings` file with info on how cleaning went
 
+* `ribocounts/`: Intermediate, fraction of rRNA from fast `RiboDetector`
+    * ex: COMO1.ribocounts.txt
+    * txt
+    * Fraction of rRNA in sample using subset of input reads
+
 * `riboreads/`: Intermediate, read IDs of `RiboDetector` output
     * ex: SRR13167436.riboreads.txt.gz
     * txt

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ Available files, and their formats:
      * `discarded` if it dropped the whole pair
      * Plus a `settings` file with info on how cleaning went
 
-* `ribocounts/`: Intermediate, fraction of rRNA from fast `RiboDetector`
-    * ex: COMO1.ribocounts.txt
+* `ribofrac/`: Intermediate, fraction of rRNA from fast `RiboDetector`
+    * ex: COMO1.ribofrac.txt
     * txt
     * Fraction of rRNA in sample using subset of input reads
 

--- a/dashboard/prepare-dashboard-data.py
+++ b/dashboard/prepare-dashboard-data.py
@@ -303,10 +303,10 @@ for project in projects:
         sample_metadata[sample]["reads"] = \
             project_sample_reads[project][sample]
 
-        rr_fname = "riboreads/%s.riboreads.txt.gz" % sample
+        rc_fname = "ribocounts/%s.ribocounts.txt" % sample
         try:
-            with gzip.open(rr_fname, 'rt') as file:
-                ribocount = sum(1 for _ in file)
+            with open(rc_fname, 'r') as file:
+                ribocount = file.readline()
             sample_metadata[sample]["ribocounts"] = ribocount
         except FileNotFoundError:
             pass

--- a/dashboard/prepare-dashboard-data.py
+++ b/dashboard/prepare-dashboard-data.py
@@ -303,11 +303,11 @@ for project in projects:
         sample_metadata[sample]["reads"] = \
             project_sample_reads[project][sample]
 
-        rc_fname = "ribocounts/%s.ribocounts.txt" % sample
+        rc_fname = "ribofrac/%s.ribofrac.txt" % sample
         try:
             with open(rc_fname, 'r') as file:
                 ribocount = file.readline()
-            sample_metadata[sample]["ribocounts"] = ribocount
+            sample_metadata[sample]["ribofrac"] = ribofrac
         except FileNotFoundError:
             pass
 

--- a/dashboard/prepare-dashboard-data.py
+++ b/dashboard/prepare-dashboard-data.py
@@ -303,10 +303,10 @@ for project in projects:
         sample_metadata[sample]["reads"] = \
             project_sample_reads[project][sample]
 
-        rc_fname = "ribofrac/%s.ribofrac.txt" % sample
+        rf_fname = "ribofrac/%s.ribofrac.txt" % sample
         try:
-            with open(rc_fname, 'r') as file:
-                ribocount = file.readline()
+            with open(rf_fname, 'r') as file:
+                ribofrac = file.readline()
             sample_metadata[sample]["ribofrac"] = ribofrac
         except FileNotFoundError:
             pass

--- a/dashboard/prepare-dashboard-data.sh
+++ b/dashboard/prepare-dashboard-data.sh
@@ -50,13 +50,13 @@ for study in $(aws s3 ls $S3_DIR | awk '{print $NF}'); do
 done | xargs -I {} -P 32 aws s3 cp {} hvreads/
 
 for study in $(aws s3 ls $S3_DIR | awk '{print $NF}'); do
-    for rc in $(aws s3 ls $S3_DIR${study}riboreads/ | \
+    for rc in $(aws s3 ls $S3_DIR${study}ribocounts/ | \
                     awk '{print $NF}'); do
-    	if [ ! -s riboreads/$rc ]; then
-	    echo $S3_DIR${study}riboreads/$rc
+    	if [ ! -s ribocounts/$rc ]; then
+	    echo $S3_DIR${study}ribocounts/$rc
 	fi
      done
-done | xargs -I {} -P 32 aws s3 cp {} riboreads/
+done | xargs -I {} -P 32 aws s3 cp {} ribocounts/
 
 $MGS_PIPELINE_DIR/dashboard/prepare-dashboard-data.py $ROOT_DIR $MGS_PIPELINE_DIR
 

--- a/dashboard/prepare-dashboard-data.sh
+++ b/dashboard/prepare-dashboard-data.sh
@@ -50,13 +50,13 @@ for study in $(aws s3 ls $S3_DIR | awk '{print $NF}'); do
 done | xargs -I {} -P 32 aws s3 cp {} hvreads/
 
 for study in $(aws s3 ls $S3_DIR | awk '{print $NF}'); do
-    for rc in $(aws s3 ls $S3_DIR${study}ribocounts/ | \
+    for rc in $(aws s3 ls $S3_DIR${study}ribofrac/ | \
                     awk '{print $NF}'); do
-    	if [ ! -s ribocounts/$rc ]; then
-	    echo $S3_DIR${study}ribocounts/$rc
+    	if [ ! -s ribofrac/$rf ]; then
+	    echo $S3_DIR${study}ribofrac/$rf
 	fi
      done
-done | xargs -I {} -P 32 aws s3 cp {} ribocounts/
+done | xargs -I {} -P 32 aws s3 cp {} ribofrac/
 
 $MGS_PIPELINE_DIR/dashboard/prepare-dashboard-data.py $ROOT_DIR $MGS_PIPELINE_DIR
 

--- a/dashboard/prepare-dashboard-data.sh
+++ b/dashboard/prepare-dashboard-data.sh
@@ -20,6 +20,7 @@ cd $ROOT_DIR/dashboard
 mkdir -p allmatches/
 mkdir -p hvreads/
 mkdir -p hvrfull/
+mkdir -p ribofrac/
 mkdir -p riboreads/
 
 if [ ! -e names.dmp ] ; then
@@ -51,7 +52,7 @@ done | xargs -I {} -P 32 aws s3 cp {} hvreads/
 
 for study in $(aws s3 ls $S3_DIR | awk '{print $NF}'); do
     for rf in $(aws s3 ls $S3_DIR${study}ribofrac/ | \
-                    awk '{print $NF}'); do
+   	    awk '{print $NF}'); do
     	if [ ! -s ribofrac/$rf ]; then
 	    echo $S3_DIR${study}ribofrac/$rf
 	fi

--- a/dashboard/prepare-dashboard-data.sh
+++ b/dashboard/prepare-dashboard-data.sh
@@ -50,7 +50,7 @@ for study in $(aws s3 ls $S3_DIR | awk '{print $NF}'); do
 done | xargs -I {} -P 32 aws s3 cp {} hvreads/
 
 for study in $(aws s3 ls $S3_DIR | awk '{print $NF}'); do
-    for rc in $(aws s3 ls $S3_DIR${study}ribofrac/ | \
+    for rf in $(aws s3 ls $S3_DIR${study}ribofrac/ | \
                     awk '{print $NF}'); do
     	if [ ! -s ribofrac/$rf ]; then
 	    echo $S3_DIR${study}ribofrac/$rf

--- a/run.py
+++ b/run.py
@@ -704,9 +704,9 @@ def print_status(args):
 
    running_processes = subprocess.check_output(["ps", "aux"]).decode("utf-8")
 
-   stages = ["raw", "cleaned", "ribocounts", "riboreads", "processed", "cladecounts", "humanviruses",
+   stages = ["raw", "cleaned", "ribofrac", "riboreads", "processed", "cladecounts", "humanviruses",
              "allmatches", "hvreads"]
-   short_stages = ["raw", "clean", "rc", "rr", "kraken", "cc", "hv", "am", "hvr"]
+   short_stages = ["raw", "clean", "rf", "rr", "kraken", "cc", "hv", "am", "hvr"]
 
    papers_to_projects = defaultdict(list) # paper -> [project]
    for bioproject in bioprojects:

--- a/run.py
+++ b/run.py
@@ -12,9 +12,13 @@ import tempfile
 import contextlib
 import subprocess
 import numpy as np
+import random
 from collections import Counter
 from collections import defaultdict
+from Bio import SeqIO
 from Bio.SeqIO.QualityIO import FastqGeneralIterator
+from Bio.Seq import Seq
+from Bio.SeqRecord import SeqRecord
 
 S3_BUCKET=None
 WORK_ROOT=None
@@ -197,13 +201,160 @@ def get_files(args, dirname, min_size=1, min_date=''):
    return set(ls_s3_dir("%s/%s/%s/" % (S3_BUCKET, args.bioproject, dirname),
                         min_size=min_size, min_date=min_date))
 
+def ribocounts(args, subset_size=1000):
+    """Fast algorithm to compute fraction of reads identified as rRNA by RiboDetector"""
+
+    available_inputs = get_files(args, "cleaned",
+                                 # tiny files are empty; ignore them
+                                 min_size=100)
+    existing_outputs = get_files(args, "ribocounts", min_date='2023-10-10')
+
+    def first_subset_fastq(file_paths, subset_size):
+        """
+        Selects the first subset of reads from gzipped fastq files.
+        Assumes that paired-end reads are in the same order in both files.
+        """
+        print(f"Counting reads in input and selecting the first {subset_size}...")
+        output_files = []
+        total_reads = 0
+        # Count the total number of reads only for the first input file
+        with gzip.open(file_paths[0], 'rt') as f:
+            total_reads = sum(1 for _ in FastqGeneralIterator(f))
+
+        for fp in file_paths:
+            actual_subset_size = 0
+
+            with gzip.open(fp, 'rt') as f:
+                # Create an output file handle
+                output_file = fp.replace(".fq.gz", ".subset.fq")
+                with open(output_file, "w") as out_handle:
+                    for index, (title, seq, qual) in enumerate(FastqGeneralIterator(f)):
+                        if index >= subset_size:
+                            break
+                        actual_subset_size += 1
+                        out_handle.write("@%s\n%s\n+\n%s\n" % (title, seq, qual))
+
+                output_files.append(output_file)
+
+        return output_files, total_reads, actual_subset_size
+
+
+    for sample in get_samples(args):
+        # Check for name of output file
+        sample_output_file = sample + ".ribocounts.txt"
+        if sample_output_file in existing_outputs: continue
+
+        total_reads_dict = {}
+        subset_reads_dict = {}
+        rrna_reads_dict = {}
+        for potential_input in available_inputs:
+            if not potential_input.startswith(sample): continue
+            if ".settings" in potential_input: continue
+            if "discarded" in potential_input: continue
+
+            # Number of output and input files must match 
+            tmp_fq_output = potential_input.replace(".gz", ".subset.nonrrna.fq")
+            tmp_fq_outputs = [tmp_fq_output]
+            inputs = [potential_input]
+
+            if ".pair1." in potential_input:
+                tmp_fq_outputs.append(tmp_fq_output.replace(".pair1.", ".pair2."))
+                inputs.append(potential_input.replace(".pair1.", ".pair2."))
+            elif ".pair2." in potential_input:
+                # Ribodetector handles pair1 and pair2 together.
+                continue
+
+            with tempdir("ribocounts", sample + " inputs") as workdir:
+                for input_fname in inputs:
+                    subprocess.check_call([
+                        "aws", "s3", "cp", "%s/%s/cleaned/%s" % (
+                            S3_BUCKET, args.bioproject, input_fname), input_fname])
+
+                    # Ribodetector gets angry if the .fq extension isn't in the filename
+                    os.rename(input_fname, input_fname.replace(".gz", ".fq.gz"))
+
+                # Add .fq extensions to input files
+                inputs = [i.replace(".gz", ".fq.gz") for i in inputs]
+
+                # Get subset of inputs
+                subsets, total_reads, subset_reads  = first_subset_fastq(inputs, subset_size)
+                subset_reads_dict[inputs[0]] = subset_reads
+                total_reads_dict[inputs[0]] = total_reads
+                
+                # Compute average read lengths. For paired-end reads, average length is
+                # computed only from pair1 reads.
+                print("Calculating average read length...")
+                def calculate_average_read_length(file_path):
+                    total_len = 0
+                    total_reads = 0
+                    with open(file_path, 'rt') as inf:
+                        for (title, sequence, quality) in FastqGeneralIterator(inf):
+                            total_len += len(sequence)
+                            total_reads += 1
+                    return round(total_len / total_reads)
+
+                avg_length = calculate_average_read_length(subsets[0])
+                print("Done. Average read length is ", avg_length)
+
+                ribodetector_cmd = [
+                    "ribodetector_cpu",
+                    "--ensure", "rrna",
+                    "--threads", "28"
+                    ]
+                ribodetector_cmd.extend(["--len", str(avg_length)])
+
+                ribodetector_cmd.append("--input")
+                ribodetector_cmd.extend(subsets)
+
+                # RiboDetector outputs fastq files containing non-rRNA sequences
+                # https://github.com/hzi-bifo/RiboDetector
+                ribodetector_cmd.append("--output")
+                ribodetector_cmd.extend(tmp_fq_outputs)
+
+                subprocess.check_call(ribodetector_cmd)
+
+                # Count number of rRNA reads in subset
+                non_rrna_count = sum(1 for _ in FastqGeneralIterator(open(tmp_fq_outputs[0], 'rt')))
+                rrna_reads_dict[inputs[0]] = subset_reads - non_rrna_count
+
+        
+        # Calculate the total number of reads across all inputs in sample
+        total_reads_all = sum(total_reads_dict.values())
+
+        # Calculate the weighted fraction for each input
+        weighted_fractions = []
+        for input_filename in total_reads_dict:
+            fraction_rrna_in_subset = rrna_reads_dict[input_filename] / subset_reads_dict[input_filename]
+            weighted_fraction = fraction_rrna_in_subset * total_reads_dict[input_filename]
+            weighted_fractions.append(weighted_fraction)
+
+        # Calculate the weighted average fraction of rRNA reads across all inputs in sample
+        total_weighted_fraction = sum(weighted_fractions)
+        weighted_rrna_fraction = total_weighted_fraction / total_reads_all
+
+        fraction_rrna = round(weighted_rrna_fraction, 4)
+        print(f"Estimated fraction of rRNA reads in {sample} = {fraction_rrna*100}%")
+
+        # Save fraction of rRNA reads
+        with tempdir("ribocounts", sample + "_output") as workdir:
+            ribocounts_file = os.path.join(workdir, f"{sample}.ribocounts.txt")
+
+            with open(ribocounts_file, 'w') as txt_file:
+                txt_file.write(str(fraction_rrna))
+
+            subprocess.check_call([
+            "aws", "s3", "cp", ribocounts_file, "%s/%s/ribocounts/" % (
+                S3_BUCKET, args.bioproject)])
+
+
+
 def riboreads(args):
     """Save title of reads identified as rRNA by RiboDetector to AWS"""
 
     available_inputs = get_files(args, "cleaned",
                                  # tiny files are empty; ignore them
                                  min_size=100)
-    existing_outputs = get_files(args, "riboreads", min_date='2023-10-01')
+    existing_outputs = get_files(args, "riboreads", min_date='2023-10-10')
         
     for sample in get_samples(args):
         # Check for name of output file
@@ -560,9 +711,9 @@ def print_status(args):
 
    running_processes = subprocess.check_output(["ps", "aux"]).decode("utf-8")
 
-   stages = ["raw", "cleaned", "ribocounts", "processed", "cladecounts", "humanviruses",
+   stages = ["raw", "cleaned", "ribocounts", "riboreads", "processed", "cladecounts", "humanviruses",
              "allmatches", "hvreads"]
-   short_stages = ["raw", "clean", "rc", "kraken", "cc", "hv", "am", "hvr"]
+   short_stages = ["raw", "clean", "rc", "rr", "kraken", "cc", "hv", "am", "hvr"]
 
    papers_to_projects = defaultdict(list) # paper -> [project]
    for bioproject in bioprojects:
@@ -635,6 +786,7 @@ STAGES_ORDERED = []
 STAGE_FNS = {}
 for stage_name, stage_fn in [("clean", clean),
                              ("riboreads", riboreads),
+                             ("ribocounts", ribocounts),
                              ("interpret", interpret),
                              ("cladecounts", cladecounts),
                              ("humanviruses", humanviruses),

--- a/run.py
+++ b/run.py
@@ -333,7 +333,7 @@ def ribocounts(args, subset_size=1000):
         weighted_rrna_fraction = total_weighted_fraction / total_reads_all
 
         fraction_rrna = round(weighted_rrna_fraction, 4)
-        print(f"Estimated fraction of rRNA reads in {sample} = {fraction_rrna*100}%")
+        print(f"Estimated fraction of rRNA reads in {sample} = {round(fraction_rrna*100, 2)}%")
 
         # Save fraction of rRNA reads
         with tempdir("ribocounts", sample + "_output") as workdir:

--- a/run.py
+++ b/run.py
@@ -346,8 +346,6 @@ def ribocounts(args, subset_size=1000):
             "aws", "s3", "cp", ribocounts_file, "%s/%s/ribocounts/" % (
                 S3_BUCKET, args.bioproject)])
 
-
-
 def riboreads(args):
     """Save title of reads identified as rRNA by RiboDetector to AWS"""
 


### PR DESCRIPTION
Added a `ribocounts()` function that selects up to `subset_size` reads from each applicable AdapterRemoval2 output, runs RiboDetector on the subset, and calculates a weighted average rRNA fraction for the entire sample. 

I checked the output of fast `ribocounts()` for Bohl 2022 and it closely matches the previous results for the fraction of rRNA reads calculated across all the reads in the sample.

| Sample ID  | fast ribocounts | actual (old ribocounts) |
|------------|--------------|-----------|
| SRR13167435| 0.156        | 0.147     |
| SRR13167436| 0.178        | 0.177     |
| SRR13167437| 0.115        | 0.115     |
| SRR13167438| 0.148        | 0.148     |
| SRR13167439| 0.110        | 0.110     |
| SRR13167440| 0.0917       | 0.0920    |
| SRR13167441| 0.130        | 0.130     |
| SRR13167442| 0.0690       | 0.0690    |
| SRR13167443| 0.135        | 0.135     |
| SRR13176755| 0.218        | 0.220     |



