### PR TITLE
Ribofrac: Check for empty files and skip samples with zero reads

### DIFF
--- a/dashboard/prepare-dashboard-data.py
+++ b/dashboard/prepare-dashboard-data.py
@@ -181,7 +181,13 @@ def count_dups(hvr_fname):
         hvr = {}
 
     by_start_end = defaultdict(list) # start, end -> read id
-    for read_id, (kraken_info, *reads) in sorted(hvr.items()):
+    for read_id, read_info in sorted(hvr.items()):
+        if type(read_info[0]) == int:
+            taxid, kraken_info, *reads = read_info
+        else:
+            taxid = -1
+            kraken_info, *reads = read_info
+
         if not reads:
             print(hvr_fname, read_id)
             continue

--- a/run.py
+++ b/run.py
@@ -359,9 +359,11 @@ def ribofrac(args, subset_size=1000):
         weights = list(total_reads_dict.values())
 
         # Calculate the weighted average fraction of rRNA reads across all inputs in sample using numpy
-        weighted_rrna_fraction = -1
-        if sum(weights) > 0:
-           np.average(fractions_rrna_in_subset, weights=weights)
+        if sum(total_reads_dict.values()) == 0:
+            # Sample has zero reads: saves "nan" to ribofrac txt file
+            weighted_rrna_fraction = np.nan
+        else:
+            weighted_rrna_fraction = np.average(fractions_rrna_in_subset, weights=weights)
 
         fraction_rrna = round(weighted_rrna_fraction, 4)
         print(f"Estimated fraction of rRNA reads in {sample} = {round(fraction_rrna*100, 2)}%")

--- a/run.py
+++ b/run.py
@@ -2,6 +2,7 @@
 
 import re
 import os
+import warnings
 import glob
 import gzip
 import json
@@ -236,11 +237,34 @@ def ribofrac(args, subset_size=1000):
 
         return output_files, total_reads, actual_subset_size
 
+    def file_integrity_check(filename):
+        """
+        Checks if the file exists and contains any reads.
+        If either condition fails, it raises a warning.
+        """
+        if not os.path.exists(filename):
+            warnings.warn(f"File {filename} does not exist!")
+            return False
+        
+        with gzip.open(filename, 'rt') as f:
+            try:
+                # Check for the first read using the iterator
+                next(FastqGeneralIterator(f))
+            except StopIteration:
+                warnings.warn(f"File {filename} contains no reads!")
+                return False
+
+        return True
+
 
     for sample in get_samples(args):
         # Check for name of output file
         sample_output_file = sample + ".ribofrac.txt"
         if sample_output_file in existing_outputs: continue
+
+        # Track for error handling
+        total_files_in_sample = 0
+        empty_files_in_sample = 0
 
         total_reads_dict = {}
         subset_reads_dict = {}
@@ -249,6 +273,7 @@ def ribofrac(args, subset_size=1000):
             if not potential_input.startswith(sample): continue
             if ".settings" in potential_input: continue
             if "discarded" in potential_input: continue
+            total_files_in_sample += 1
 
             # Number of output and input files must match 
             tmp_fq_output = potential_input.replace(".gz", ".subset.nonrrna.fq")
@@ -267,9 +292,18 @@ def ribofrac(args, subset_size=1000):
                     subprocess.check_call([
                         "aws", "s3", "cp", "%s/%s/cleaned/%s" % (
                             S3_BUCKET, args.bioproject, input_fname), input_fname])
+                    
+                    # Check file integrity
+                    file_valid = file_integrity_check(input_fname)
+                    if not file_valid:
+                        empty_files_in_sample += 1
 
                     # Ribodetector gets angry if the .fq extension isn't in the filename
                     os.rename(input_fname, input_fname.replace(".gz", ".fq.gz"))
+
+                if total_files_in_sample == empty_files_for_sample:
+                    print(f"Skipping {sample}... all files are empty.")
+                    continue
 
                 # Add .fq extensions to input files
                 inputs = [i.replace(".gz", ".fq.gz") for i in inputs]

--- a/run.py
+++ b/run.py
@@ -349,23 +349,22 @@ def ribofrac(args, subset_size=1000):
                 non_rrna_count = sum(1 for _ in FastqGeneralIterator(open(tmp_fq_outputs[0], 'rt')))
                 rrna_reads_dict[inputs[0]] = subset_reads - non_rrna_count
 
-        # Extract the fractions of rRNA reads for each input
-        fractions_rrna_in_subset = [
-            rrna_reads_dict[input_filename] / subset_reads_dict[input_filename]
-            for input_filename in total_reads_dict
-        ]
-
-        # Use the total number of reads for each input as weights
-        weights = list(total_reads_dict.values())
-
         # Calculate the weighted average fraction of rRNA reads across all inputs in sample using numpy
         if sum(total_reads_dict.values()) == 0:
             # Sample has zero reads: saves "nan" to ribofrac txt file
-            weighted_rrna_fraction = np.nan
+            fraction_rrna = np.nan
         else:
-            weighted_rrna_fraction = np.average(fractions_rrna_in_subset, weights=weights)
+            # Extract the fractions of rRNA reads for each input
+            fractions_rrna_in_subset = [
+                rrna_reads_dict[input_filename] / subset_reads_dict[input_filename]
+                for input_filename in total_reads_dict
+            ]
 
-        fraction_rrna = round(weighted_rrna_fraction, 4)
+            # Use the total number of reads for each input as weights
+            weights = list(total_reads_dict.values())
+            weighted_rrna_fraction = np.average(fractions_rrna_in_subset, weights=weights)
+            fraction_rrna = round(weighted_rrna_fraction, 4)
+
         print(f"Estimated fraction of rRNA reads in {sample} = {round(fraction_rrna*100, 2)}%")
 
         # Save fraction of rRNA reads

--- a/run.py
+++ b/run.py
@@ -359,7 +359,9 @@ def ribofrac(args, subset_size=1000):
         weights = list(total_reads_dict.values())
 
         # Calculate the weighted average fraction of rRNA reads across all inputs in sample using numpy
-        weighted_rrna_fraction = np.average(fractions_rrna_in_subset, weights=weights)
+        weighted_rrna_fraction = -1
+        if sum(weights) > 0:
+           np.average(fractions_rrna_in_subset, weights=weights)
 
         fraction_rrna = round(weighted_rrna_fraction, 4)
         print(f"Estimated fraction of rRNA reads in {sample} = {round(fraction_rrna*100, 2)}%")

--- a/run.py
+++ b/run.py
@@ -350,20 +350,16 @@ def ribofrac(args, subset_size=1000):
                 rrna_reads_dict[inputs[0]] = subset_reads - non_rrna_count
 
         # Calculate the weighted average fraction of rRNA reads across all inputs in sample using numpy
-        if sum(total_reads_dict.values()) == 0:
-            # Sample has zero reads: saves "nan" to ribofrac txt file
-            fraction_rrna = np.nan
-        else:
-            # Extract the fractions of rRNA reads for each input
-            fractions_rrna_in_subset = [
+        # Extract the fractions of rRNA reads for each input
+        fractions_rrna_in_subset = [
                 rrna_reads_dict[input_filename] / subset_reads_dict[input_filename]
                 for input_filename in total_reads_dict
             ]
 
-            # Use the total number of reads for each input as weights
-            weights = list(total_reads_dict.values())
-            weighted_rrna_fraction = np.average(fractions_rrna_in_subset, weights=weights)
-            fraction_rrna = round(weighted_rrna_fraction, 4)
+        # Use the total number of reads for each input as weights
+        weights = list(total_reads_dict.values())
+        weighted_rrna_fraction = np.average(fractions_rrna_in_subset, weights=weights)
+        fraction_rrna = round(weighted_rrna_fraction, 4)
 
         print(f"Estimated fraction of rRNA reads in {sample} = {round(fraction_rrna*100, 2)}%")
 


### PR DESCRIPTION
In past commits to main I added a feature to `ribofrac()` that counted the total reads in `total_reads_dict` and returned `np.nan` if the sample had zero reads. However, when running the new NAO data through `ribofrac()`, several samples returned `np.nan` even though they definitely has reads in them. 

Once possible cause of this issue is that the files where somehow empty or not appropriately copied over from AWS. I've added a `file_integrity_check()` function that checks potential inputs (minus the ".settings" and ".discarded" files) to see if 1) the path exists after copying down from AWS, and 2) if the files contain any reads. 

If all the potential inputs do not contain any reads or don't exist, the `ribofrac()` will skip the sample and not output anything to AWS. This seems better than outputting `np.nan` without being certain that files were correctly processed, potentially misleading people. It also allows the pipeline to be re-run without the appearance of existing, potentially incorrect, ribofrac entries.