### PR TITLE
dashboard: fix bug where we were getting zero counts for human-infecting viruses

### DIFF
--- a/dashboard/prepare-dashboard-data.py
+++ b/dashboard/prepare-dashboard-data.py
@@ -217,7 +217,11 @@ def count_dups(hvr_fname):
 
     kraken_info_counts = Counter() # kraken_info -> non-duplicate count
     for (start, end), read_ids in sorted(by_start_end.items()):
-        first_kraken_info = hvr[read_ids[0]][0]
+        read_info = hvr[read_ids[0]]
+        if type(read_info[0]) == int:
+            _, first_kraken_info, *_ = read_info
+        else:
+            first_kraken_info, *_ = read_info
         kraken_info_counts[first_kraken_info] += 1
     return kraken_info_counts
 


### PR DESCRIPTION


The problem was that this piece of code processing human infecting virus counts for duplicates hadn't been updated when we added taxid to hvreads.json