### PR TITLE
Add a script for reprocessing all the bioprojects in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,31 +339,33 @@ We normally run this pipeline on EC2 instances, generally c6a.8xlarge ones.
 The pipeline runs serially within each bioproject. It would be possible to
 extend it to be much more parallel, but we haven't felt the need yet.
 
-When we parallize it we usually do it over bioprojects.  For example:
+When we parallize it we usually do it over bioprojects, by running
+./reprocess-bioprojects.py and specifying a maximum number of parallel jobs.
+For example:
 
 ```
-mgs-pipeline $ for bioproject in $(ls bioprojects/) ; do
-    screen -d -m ./run.py --bioproject $bioproject --arguments-here
-done
-mgs-pipeline $ for bioproject in $(ls ../mgs-restricted/bioprojects/) ; do
-    screen -d -m ./run.py --bioproject $bioproject --restricted --arguments-here
-done
+mgs-pipeline $ ./reprocess-bioprojects.py 12 prefix --run-arguments-here
 ```
 
-This will run the pipeline once for each bioproject, each in its own screen
-session.  If the stages you're running require a lot of memory or disk,
-however, you should do it serially instead:
+This will run the pipeline once for each bioproject, including restricted
+bioprojects if available in ../mgs-restricted.  If the stages you're running
+require a lot of memory or disk, use a number lower than 12, potentially 1.
+
+Job output is under log/ in files named by the date and the prefix you supply.
+So if I ran the above on 2023-01-01 I'd expect to see files like:
 
 ```
-mgs-pipeline $ for bioproject in $(ls bioprojects/) ; do
-    ./run.py --bioproject $bioproject --arguments-here
-done ; for bioproject in $(ls ../mgs-restricted/bioprojects/) ; do
-    ./run.py --bioproject $bioproject --restricted --arguments-here
-done
-
+...
+log/2023-01-01.prefix.PRJNA924011
+log/2023-01-01.prefix.PRJNA943189
+log/2023-01-01.prefix.PRJNA966185
+...
 ```
 
-### Parallelization Oversight
+If the job fails, the last line in the log file will start with "ERROR:" and
+then have the exit code.
+
+### Screen Oversight
 
 You can check in on parallelized jobs under screen with:
 

--- a/reprocess-bioprojects.py
+++ b/reprocess-bioprojects.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+# Runs the pipeline with the provided arguments across all bioprojects.  Useful
+# when there's a new stage, or a stage needs to be re-run.
+#
+# Usage: ./reprocess-bioprojects.sh <max_jobs> <log prefix> [./run.py arguments]
+#
+# Examples:
+#   ./reprocess-bioprojects.sh 12 rl --stages readlengths
+#   ./reprocess-bioprojects.sh 2 nr --skip-stages ribocounts,ribofrac
+#
+
+import os
+import sys
+import datetime
+import subprocess
+from concurrent.futures import ThreadPoolExecutor
+
+log_date = datetime.datetime.now().date().isoformat()
+log_dir = "log"
+if not os.path.exists(log_dir):
+    os.mkdir(log_dir)
+
+def prepare_job(bioproject, log_prefix, *args):
+    logfile = "%s/%s.%s.%s" % (log_dir, log_date, log_prefix, bioproject)
+    return logfile, ["./run.py", "--bioproject", bioproject, *args]
+
+def run_job(job):
+    logfile, cmd = job
+    with open(logfile, "w") as outf:
+        result = subprocess.run(cmd, stdout=outf, stderr=subprocess.STDOUT)
+        if result.returncode != 0:
+            outf.write("ERROR: %s\n" % (result.returncode))
+
+def start(max_jobs, log_prefix, *args):
+    assert max_jobs.isdigit()
+    max_jobs = int(max_jobs)
+    assert not log_prefix.startswith("--")
+
+    regular_bioprojects = os.listdir("bioprojects")
+
+    restricted_bioprojects = []
+    restricted_dir = os.path.join("..", "mgs-restricted")
+    if os.path.exists(restricted_dir):
+        restricted_bioprojects = os.listdir(
+            os.path.join(restricted_dir, "bioprojects"))
+
+    job_queue = []
+
+    for bioproject in regular_bioprojects:
+        job_queue.append(prepare_job(bioproject, log_prefix, *args))
+    for bioproject in restricted_bioprojects:
+        job_queue.append(prepare_job(
+            bioproject, log_prefix, "--restricted", *args))
+
+    with ThreadPoolExecutor(max_workers=max_jobs) as executor:
+        for job in job_queue:
+            executor.submit(run_job, job)
+
+if __name__ == "__main__":
+   start(*sys.argv[1:])

--- a/reprocess-bioprojects.py
+++ b/reprocess-bioprojects.py
@@ -3,16 +3,18 @@
 # Runs the pipeline with the provided arguments across all bioprojects.  Useful
 # when there's a new stage, or a stage needs to be re-run.
 #
-# Usage: ./reprocess-bioprojects.sh <max_jobs> <log prefix> [./run.py arguments]
+# Usage: ./reprocess-bioprojects.sh \
+#    --max-jobs <N> --log-prefix <LP> -- arguments-for-run
 #
-# Examples:
-#   ./reprocess-bioprojects.sh 12 rl --stages readlengths
-#   ./reprocess-bioprojects.sh 2 nr --skip-stages ribocounts,ribofrac
+# Example: ./reprocess-bioprojects.sh \
+#    --max-jobs 12 --log-prefix rl -- --stages readlengths
 #
+# You can pass --bioprojects A,B,C to run on only a subset of projects.
 
 import os
 import sys
 import datetime
+import argparse
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
 
@@ -21,9 +23,17 @@ log_dir = "log"
 if not os.path.exists(log_dir):
     os.mkdir(log_dir)
 
-def prepare_job(bioproject, log_prefix, *args):
+regular_bioprojects = os.listdir("bioprojects")
+
+restricted_bioprojects = []
+restricted_dir = os.path.join("..", "mgs-restricted")
+if os.path.exists(restricted_dir):
+    restricted_bioprojects = os.listdir(
+        os.path.join(restricted_dir, "bioprojects"))
+
+def prepare_job(bioproject, log_prefix, run_args):
     logfile = "%s/%s.%s.%s" % (log_dir, log_date, log_prefix, bioproject)
-    return logfile, ["./run.py", "--bioproject", bioproject, *args]
+    return logfile, ["./run.py", "--bioproject", bioproject, *run_args]
 
 def run_job(job):
     logfile, cmd = job
@@ -32,30 +42,50 @@ def run_job(job):
         if result.returncode != 0:
             outf.write("ERROR: %s\n" % (result.returncode))
 
-def start(max_jobs, log_prefix, *args):
-    assert max_jobs.isdigit()
-    max_jobs = int(max_jobs)
-    assert not log_prefix.startswith("--")
-
-    regular_bioprojects = os.listdir("bioprojects")
-
-    restricted_bioprojects = []
-    restricted_dir = os.path.join("..", "mgs-restricted")
-    if os.path.exists(restricted_dir):
-        restricted_bioprojects = os.listdir(
-            os.path.join(restricted_dir, "bioprojects"))
-
+def parallelize(max_jobs, log_prefix, bioprojects, run_args):
     job_queue = []
 
-    for bioproject in regular_bioprojects:
-        job_queue.append(prepare_job(bioproject, log_prefix, *args))
-    for bioproject in restricted_bioprojects:
-        job_queue.append(prepare_job(
-            bioproject, log_prefix, "--restricted", *args))
+    for bioproject in bioprojects:
+        args = run_args[:]
+        if bioproject in restricted_bioprojects:
+            args.append("--restricted")
+        elif bioproject in regular_bioprojects:
+            pass
+        else:
+            raise Exception("Unknown bioproject %r" % bioproject)
+
+        job_queue.append(prepare_job(bioproject, log_prefix, args))
 
     with ThreadPoolExecutor(max_workers=max_jobs) as executor:
         for job in job_queue:
             executor.submit(run_job, job)
 
+def start():
+    argv = sys.argv[1:]
+    if "--" not in argv:
+        raise Exception("Use -- to separate arguments to ./run.py.")
+
+    our_args = argv[:argv.index("--")]
+    run_args = argv[argv.index("--") + 1:]
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--max-jobs', metavar='N', type=int, required=True,
+        help='maximum number of jobs to run at once',)
+    parser.add_argument(
+        '--log-prefix', required=True,
+        help='Log prefix, for storing this run under log/')
+    parser.add_argument(
+        '--bioprojects',
+        help='The IDs of the bioproject to process, comma separated')
+    args = parser.parse_args(our_args)
+
+    if args.bioprojects:
+        bioprojects = args.bioprojects.split(",")
+    else:
+        bioprojects = regular_bioprojects + restricted_bioprojects
+
+    parallelize(args.max_jobs, args.log_prefix, bioprojects, run_args)
+
 if __name__ == "__main__":
-   start(*sys.argv[1:])
+   start()


### PR DESCRIPTION
Replaces snippets of code in the README that didn't do logging or let you tune the number of parallel jobs.