### PR TITLE
Automatically add sample metadata when importing new bioprojects

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,17 +222,9 @@ Available files, and their formats:
    have to finish before you get to step #5, it just needs a small head start.
    * If some files hit errors it's fine to re-run; it skips any files that are
      already complete.
-3. Make a directory `bioprojects/[accession]/metadata` and:
+3. Navigate to `bioprojects/[accession]/metadata` and:
    b. Create `bioprojects/[accession]/metadata/name.txt` with the short name of
       the associated paper.  For example, `Rothman 2021`.
-   c. Create `bioprojects/[accession]/metadata/metadata.tsv` with a list of the
-      sample accessions in the first column and anything else you want to record about the sample in the later
-      columns.  If you don't have the rest of the metadata sorted out yet and
-      just want to unblock the pipeline you can put the accessions only with:
-
-          curl -sS 'https://www.ebi.ac.uk/ena/portal/api/filereport?accession=PRJNA648796&result=read_run&limit=0' | \
-            grep -v ^run_accession | \
-            awk '{print $1}' > metadata.tsv
 
 4. Make a directory `papers/AuthorYear/` (matching `name.txt` but without the
    space) and:
@@ -271,6 +263,15 @@ When we do want to build our own database kraken2-build has good [documentation
 here](https://github.com/DerrickWood/kraken2/blob/master/docs/MANUAL.markdown#custom-databases).
 
 ## Dependencies
+
+### E-utilities (for working with NCBI)
+See the NCBI [documentation](https://www.ncbi.nlm.nih.gov/books/NBK179288/). 
+```
+sh -c "$(curl -fsSL https://ftp.ncbi.nlm.nih.gov/entrez/entrezdirect/install-edirect.sh)"
+export PATH=${HOME}/edirect:${PATH}
+sudo yum install perl-Time-HiRes
+
+```
 
 ### AdapterRemoval2
 

--- a/import-accession.sh
+++ b/import-accession.sh
@@ -2,27 +2,52 @@
 
 if [ $# -lt 1 ]; then
     echo "Usage: ./import-accession.sh <accessions>"
+    exit 1
 fi
 
-metadata_file="metadata-ncbi.tsv"
+# Function to check if E-utilities are installed
+check_eutilities() {
+    if ! command -v esearch &> /dev/null; then
+        echo "E-utilities are not installed. Please refer to the dependencies section of the README."
+        return 1
+    else
+        return 0
+    fi
+}
 
 for ACCESSION in "$@"; do
-    # Define the directory based on BioProject ID
-    metadata_dir="bioprojects/${ACCESSION}/metadata"
-    mkdir -p "$metadata_dir"
-    metadata_file="${metadata_dir}/metadata-ncbi.tsv"
-
     ENDPOINT="https://www.ebi.ac.uk/ena/portal/api/filereport"
     PARAMS="?accession=${ACCESSION}&fields=fastq_ftp&format=tsv"
     PARAMS="${PARAMS}&result=read_run&download=true&limit=0"
 
-    curl -sS "${ENDPOINT}${PARAMS}" | \
-        grep -v fastq_ftp | \
-        awk '{print $NF}' | \
-        tr ';' '\n' | \
-        xargs -P 4 -I {} ./import-accession-single.sh $ACCESSION {}
+    # Fetch SRA data and check if any files are returned
+    SRA_FILES=$(curl -sS "${ENDPOINT}${PARAMS}" | grep -v fastq_ftp)
 
-    # Fetch and append metadata
-    echo "Fetching metadata for $ACCESSION"
-    (esearch -db sra -query "$ACCESSION" | efetch -format runinfo || echo "$ACCESSION") >> "$metadata_file"
+    if [ -n "$SRA_FILES" ]; then
+        # Define the directory based on BioProject ID
+        metadata_dir="bioprojects/${ACCESSION}/metadata"
+        mkdir -p "$metadata_dir"
+
+        # Download SRA data
+        echo "$SRA_FILES" | awk '{print $NF}' | tr ';' '\n' | xargs -P 4 -I {} ./import-accession-single.sh $ACCESSION {}
+
+        # Create metadata.tsv with SRA run names
+        echo "Run" > "${metadata_dir}/metadata.tsv"
+        echo "$SRA_FILES" | awk '{print $1}' >> "${metadata_dir}/metadata.tsv"
+
+        if check_eutilities; then
+            # Fetch metadata from NCBI
+            echo "Fetching metadata for $ACCESSION from NCBI"
+            METADATA=$(esearch -db sra -query "$ACCESSION" | efetch -format runinfo)
+
+            if [ -n "$METADATA" ] && [ "$(echo "$METADATA" | grep -v '^Run,' | wc -l)" -gt 0 ]; then
+                echo "$METADATA" > "${metadata_dir}/metadata-ncbi.tsv"
+            else
+                echo "No metadata was found for $ACCESSION on NCBI."
+            fi
+        fi
+    else
+        echo "No files found for accession $ACCESSION"
+    fi
 done
+

--- a/import-accession.sh
+++ b/import-accession.sh
@@ -4,7 +4,14 @@ if [ $# -lt 1 ]; then
     echo "Usage: ./import-accession.sh <accessions>"
 fi
 
+metadata_file="metadata-ncbi.tsv"
+
 for ACCESSION in "$@"; do
+    # Define the directory based on BioProject ID
+    metadata_dir="bioprojects/${ACCESSION}/metadata"
+    mkdir -p "$metadata_dir"
+    metadata_file="${metadata_dir}/metadata-ncbi.tsv"
+
     ENDPOINT="https://www.ebi.ac.uk/ena/portal/api/filereport"
     PARAMS="?accession=${ACCESSION}&fields=fastq_ftp&format=tsv"
     PARAMS="${PARAMS}&result=read_run&download=true&limit=0"
@@ -14,4 +21,8 @@ for ACCESSION in "$@"; do
         awk '{print $NF}' | \
         tr ';' '\n' | \
         xargs -P 4 -I {} ./import-accession-single.sh $ACCESSION {}
+
+    # Fetch and append metadata
+    echo "Fetching metadata for $ACCESSION"
+    (esearch -db sra -query "$ACCESSION" | efetch -format runinfo || echo "$ACCESSION") >> "$metadata_file"
 done


### PR DESCRIPTION
This PR adds a few features:
1. Automatically make the `/bioproject/{bioprojects}/metadata` dir and populate the `metadata.tsv` file with sample-ids when fetching the actual sequencing data. 
2. Fetch the SRA metadata from NCBI using their E-utilities API and save in /bioproject/{bioprojects}/metadata/metadata-ncbi.tsv. 

The "Run" column of the NCBI metadata should match the first column of the `metadata.tsv` but this may not always be the case (since the data is being downloaded from www.ebi.ac.uk?) hence we still use the `metadata.tsv` file. 

Note - I would also like to add a column name row to `metadata.csv` to better document additional metadata we might add. I haven't done this yet is it will require modifying `prepare-dashboard.py` (and maybe other files?). 