### PR TITLE
alignments: align all reads, not just hvreads

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,12 +164,14 @@ Available files, and their formats:
    * Read ID to Kraken output and cleaned read
 
 * `alignments/`: Output, alignment data that will later back the dashboard.
-   * Ex: SRR21452137.alignments.tsv
-   * TSV
-   * One record for each record in the hvreads that Bowtie2 was able to map
-     back to a known human-infecting virus.  Note that we've set the quality
-     score very low here, and you likely want to filter some of these out based
-     on a combination of alignment score and trimmed read length.
+   * Ex: `SRR21452137.alignments.tsv.gz`,
+   * Compressed TSV
+   * One record for each read that Bowtie2 was able to map back
+     to a known human-infecting virus.  Note that we've set the quality score
+     to the minimum and you likely want to filter some of these out based on a
+     combination of alignment score and trimmed read length.
+   * Non-collapsed reads will appear twice, one for the forward read and then
+     one for the reverse.
    * Columns:
      * Read ID
      * Best-match genome

--- a/compute-alignments.sh
+++ b/compute-alignments.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# I wish I could do this in pure python, which would have more robust error
+# handling, but I'm not sure how to write this kind of branching command tree
+# with the subprocess module.
+
+set -e
+set +x
+
+CMD="/home/ec2-user/bowtie2-2.5.2-linux-x86_64/bowtie2"
+CMD+=" --local"
+CMD+=" -x /home/ec2-user/mgs-pipeline/bowtie/human-viruses"
+CMD+=" --threads 8"
+CMD+=" --very-sensitive-local"
+CMD+=" --score-min G,1,0"
+CMD+=" --mp 4,1"
+CMD+=" --no-unal"
+CMD+=" --no-sq"
+CMD+=" -S $1"
+
+if [ $# = 2 ]; then
+    $CMD -U <(aws s3 cp $2 - | gunzip)
+elif [ $# = 3 ]; then
+    $CMD -1 <(aws s3 cp $2 - | gunzip) -2 <(aws s3 cp $3 - | gunzip)
+else
+    >&2 echo "usage: $0 <sam_out> <fastq_in> [fastq2_in]"
+fi

--- a/run.py
+++ b/run.py
@@ -964,6 +964,8 @@ def alignments(args):
                      query_name = bits[0]
                      genomeid = bits[2]
                      ref_start = bits[3]
+                     # The start position is 1-indexed, but we use 0-indexing.
+                     ref_start = int(ref_start) - 1
                      cigarstring = bits[5]
                      query_len = len(bits[9])
 
@@ -972,9 +974,7 @@ def alignments(args):
                         if token.startswith("AS:i:"):
                            as_val = token.replace("AS:i:", "")
                      assert as_val
-
-                     # The AS value is 1-indexed, but we use 0-indexing.
-                     query_pos = int(as_val) - 1
+                     as_val = int(as_val)
 
                      taxid, genome_name = genomeid_to_taxid[genomeid]
                      outf.write(
@@ -984,7 +984,7 @@ def alignments(args):
                            taxid,
                            cigarstring,
                            ref_start,
-                           query_pos,
+                           as_val,
                            query_len))
 
          subprocess.check_call([


### PR DESCRIPTION
Some HV reads are not identified by Kraken, so cast a wider net by running Bowtie across all cleaned reads.

We won't use all of these: some Kraken correctly can tell are Human etc which Bowtie (with the HV-only DB we're using) has no insight into, and others have such low alignment scores that they may as well be junk (but we haven't yet decided which score to use as a cutoff).  They're small enough, though, that no harm in keeping them.

Note that this uses the newer streaming pattern where we don't write any large files to disk (so we can run more things at once).

Instead of using `pysam` I now manually parse the `.sam` file so I can run Bowtie with `--no-sq`.  The useless `@SQ` header lines make the `.sam` files enormous, enough that I'm nervous about running many copies of this at once.