### PR TITLE
ribofrac: fix typo

### DIFF
--- a/run.py
+++ b/run.py
@@ -388,7 +388,7 @@ def ribofrac(args, subset_size=1000):
                         input_fname, input_fname.replace(".gz", ".fq.gz")
                     )
 
-                if total_files_in_sample == empty_files_for_sample:
+                if total_files_in_sample == empty_files_in_sample:
                     print(f"Skipping {sample}... all files are empty.")
                     continue
 


### PR DESCRIPTION
A few months ago I noticed that ribofrac was giving errors like:

```
Traceback (most recent call last):
  File "./run.py", line 1551, in <module>
    start()
  File "./run.py", line 1547, in start
    STAGE_FNS[stage](args)
  File "./run.py", line 391, in ribofrac
    if total_files_in_sample == empty_files_for_sample:
NameError: name 'empty_files_for_sample' is not defined
```

I should have flagged this at the time, but I was lazy and just started passing `--skip-stages=ribofrac` and moved on...

Debugging this now, it seems that this was introduced in 574827d514009004712e5eee09a95a48ff5af93e and was a simple typo.

With this fixed, ribofrac now runs to completion again.