### PR TITLE
Warn the user if they've accidentally included the extension in their sample names

### DIFF
--- a/run.py
+++ b/run.py
@@ -68,6 +68,11 @@ def get_samples(args):
     ) as inf:
         samples = [line.strip().split("\t")[0] for line in inf]
 
+    for sample in samples:
+        if "." in sample:
+            raise Exception("Bad sample for %s: %s" % (
+                args.delivery, sample))
+
     decorated_samples = [
         (get_sample_priority(sample), sample)
         for sample in samples]


### PR DESCRIPTION
This has bitten me before, and just got Simon.

Tested manually, and also verified that no existing sample has a dot in the name.